### PR TITLE
Sort files on directory read to keep them ordered

### DIFF
--- a/scripts/instruct-pix2pix.py
+++ b/scripts/instruct-pix2pix.py
@@ -87,7 +87,7 @@ def generate(
         return [seed, text_cfg_scale, image_cfg_scale, None]
 
     if batch_in_check and os.path.exists(batch_in_dir):
-        for filename in os.listdir(batch_in_dir):
+        for filename in sorted(os.listdir(batch_in_dir)):
             with open(os.path.join(batch_in_dir, filename), 'rb') as f: # open in readonly mode
                 try:
                     im=Image.open(f)


### PR DESCRIPTION
`os.listdir()` doesn't respect the filename order, so this will sort the list before processing in order to keep the outputs in the same order as the inputs.  Critical for video frame processing.

Example without this change:
```Adding image: 196.jpg
Adding image: 175.jpg
Adding image: 169.jpg
Adding image: 124.jpg
Adding image: 138.jpg
Adding image: 024.jpg
```